### PR TITLE
AITEAM-63: remove all traces of `deploy_environment` from SageMaker orb

### DIFF
--- a/src/commands/create_endpoint_configuration.yml
+++ b/src/commands/create_endpoint_configuration.yml
@@ -11,9 +11,6 @@ parameters:
   bucket:
     description: S3 bucket for the model
     type: string
-  deploy_environment:
-    description: Deploy ENV
-    type: string
   circle_pipeline_id:
     description: CircleCI pipeline ID
     type: string
@@ -34,7 +31,6 @@ steps:
       description: create an endpoint configuration
       environment:
         MODEL_NAME: << parameters.model_name >>
-        DEPLOY_ENVIRONMENT: << parameters.deploy_environment >>
         CIRCLE_PIPELINE_ID: << parameters.circle_pipeline_id >>
         S3_BUCKET_NAME: << parameters.bucket >>
         REGION_NAME: << parameters.region_name >>

--- a/src/commands/deploy_endpoint.yml
+++ b/src/commands/deploy_endpoint.yml
@@ -10,9 +10,6 @@ parameters:
   model_desc:
     description: sagemaker model desription
     type: string
-  deploy_environment:
-    description: Deploy ENV
-    type: string
   circle_pipeline_id:
     description: CircleCI pipeline ID
     type: string
@@ -45,7 +42,6 @@ steps:
       environment:
         MODEL_NAME: << parameters.model_name >>
         MODEL_DESC: << parameters.model_desc >>
-        DEPLOY_ENVIRONMENT: << parameters.deploy_environment >>
         CIRCLE_PIPELINE_ID: << parameters.circle_pipeline_id >>
         CIRCLE_PROJECT_ID: << parameters.circle_project_id >>
         S3_BUCKET_NAME: << parameters.bucket >>

--- a/src/examples/deploy_model.yml
+++ b/src/examples/deploy_model.yml
@@ -14,14 +14,12 @@ usage:
         - aws-sagemaker/create_model:
             name: create-model
             model_name: replace_with_model_name
-            deploy_environment: replace_with_environment
             pipeline_id: << pipeline.id >>
             bucket: replace_with_s3_bucket_name
             region_name: replace_with_region_name
         - aws-sagemaker/create_endpoint_configuration:
             name: create-endpoint-configuration
             model_name: replace_with_model_name
-            deploy_environment: replace_with_environment
             pipeline_id: << pipeline.id >>
             bucket: replace_with_s3_bucket_name
             region_name: replace_with_region_name
@@ -31,7 +29,6 @@ usage:
             name: deploy-endpoint
             model_name: replace_with_model_name
             model_desc: replace_with_description
-            deploy_environment: replace_with_environment
             pipeline_id: <<pipeline.id>>
             project_id: replace_with_project_id
             bucket: replace_with_s3_bucket_name

--- a/src/examples/deploy_model_with_endpoint_config_name.yml
+++ b/src/examples/deploy_model_with_endpoint_config_name.yml
@@ -11,7 +11,6 @@ usage:
             name: deploy-endpoint
             model_name: replace_with_model_name
             model_desc: replace_with_description
-            deploy_environment: replace_with_environment
             pipeline_id: <<pipeline.id>>
             project_id: replace_with_project_id
             bucket: replace_with_s3_bucket_name

--- a/src/jobs/create_endpoint_configuration.yml
+++ b/src/jobs/create_endpoint_configuration.yml
@@ -5,9 +5,6 @@ docker:
   - image: cimg/base:current-22.04
 
 parameters:
-  deploy_environment:
-    description: deployment environment
-    type: string
   circle_pipeline_id:
     description: CircleCI Pipeline ID
     type: string
@@ -36,7 +33,6 @@ steps:
   - create_endpoint_configuration:
       model_name: << parameters.model_name >>
       bucket: << parameters.bucket >>
-      deploy_environment: << parameters.deploy_environment >>
       circle_pipeline_id: << parameters.circle_pipeline_id >>
       region_name: << parameters.region_name >>
       endpoint_instance_type: << parameters.endpoint_instance_type >>

--- a/src/jobs/deploy_endpoint.yml
+++ b/src/jobs/deploy_endpoint.yml
@@ -5,9 +5,6 @@ docker:
   - image: cimg/base:current-22.04
 
 parameters:
-  deploy_environment:
-    description: deployment environment
-    type: string
   circle_pipeline_id:
     description: CircleCI Pipeline ID
     type: string
@@ -48,7 +45,6 @@ steps:
       model_name: << parameters.model_name >>
       bucket: << parameters.bucket >>
       model_desc: << parameters.model_desc >>
-      deploy_environment: << parameters.deploy_environment >>
       circle_pipeline_id: << parameters.circle_pipeline_id >>
       circle_project_id: << parameters.circle_project_id >>
       region_name: << parameters.region_name >>

--- a/src/scripts/main.sh
+++ b/src/scripts/main.sh
@@ -114,7 +114,7 @@ repo_name="cci-sagemaker"
 # binary="${orb_bin_dir}/${repo_name}"
 # TODO: Make the version configurable via parameter
 # Don't forget the v!
-binary_version="v0.0.13"
+binary_version="v0.0.14"
 basic_name="cci-sagemaker"
 binary_name="${basic_name}-${binary_version}-${PLATFORM}-${ARCH}"
 binary_zip="${orb_bin_dir}/${binary_name}.zip"


### PR DESCRIPTION
Ticket: [AITEAM-63](https://circleci.atlassian.net/browse/AITEAM-63)

# Rationale

Releases now has the concept of "environments", so one component can exist in many environments.

We need to stop using `deploy_environment` in the SageMaker orb since it's a bad user experience and requires charging customers 2x for what is in essence the same component.

# Changes

- removed all traces of `deploy_environment` from the SageMaker orb.

[AITEAM-63]: https://circleci.atlassian.net/browse/AITEAM-63?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ